### PR TITLE
show db_cstr in custom_sql service description

### DIFF
--- a/lib/python3/cmk/special_agents/db/basedb.py
+++ b/lib/python3/cmk/special_agents/db/basedb.py
@@ -384,6 +384,7 @@ class BaseDBStrategy(agent_db.AgentDBLog):
         if check_header == "custom_sql":
             checkoutput.update({"backend": self.backend})
             checkoutput.update({"backend_service_prefix": self.backend_service_prefix})
+            checkoutput.update({"db_cstr": self.db_cstr})
             checkoutput.update({"statement_name": check_header})
 
             checkoutput["result"] = list(

--- a/lib/python3/cmk_addons/plugins/agent_db/agent_based/custom_sql.py
+++ b/lib/python3/cmk_addons/plugins/agent_db/agent_based/custom_sql.py
@@ -28,7 +28,11 @@ def parse_custom_sql(string_table):
         if "item" not in json_content:
             # Multiple values per query are not supported yet
             continue
-        item = f"{json_content['backend_service_prefix']} Custom {json_content['item']}"
+            
+        if "instance_in_item" not in json_content:
+            item = f"{json_content['backend_service_prefix']} Custom {json_content['item']}"
+        else:
+            item = f"{json_content['backend_service_prefix']} {json_content['db_cstr'].upper()} Custom {json_content['item']}"
         ret.update({item: json_content})
     return ret
 


### PR DESCRIPTION
If the `instance_in_item: true` switch is set in agent_db.yml for a custom_sql statement, we also display the db_cstr in the service description. This is particularly useful for Oracle RAC clusters, when running queries on `PDB_PLUG_IN_VIOLATIONS`.