### PR TITLE
Add Support for multiline custom SQL Statements

### DIFF
--- a/lib/python3/cmk/special_agents/db/basedb.py
+++ b/lib/python3/cmk/special_agents/db/basedb.py
@@ -50,6 +50,13 @@ class BaseDBStrategy(agent_db.AgentDBLog):
         self.db_cursor_timeout_sec = db_cursor_timeout_sec
         self.log.debug("Initializing Base DB Strategy")
 
+        # Populated by query() with the column names (from cursor.description)
+        # of the last executed statement, one tuple per executed SQL part.
+        # Used to resolve item_columns/value_column when they are given as
+        # column names instead of numeric indices. Postgres does not use this
+        # (its query() already yields the header row as part of the result).
+        self.last_column_names = None
+
         # Initialize the database connection
         # self.init_db_connection(db_host, db_user, db_pass, db_cstr, db_port)
 
@@ -382,16 +389,29 @@ class BaseDBStrategy(agent_db.AgentDBLog):
         checkoutput = {"result": ""}
 
         if check_header == "custom_sql":
-            checkoutput.update({"backend": self.backend})
-            checkoutput.update({"backend_service_prefix": self.backend_service_prefix})
-            checkoutput.update({"db_cstr": self.db_cstr})
-            checkoutput.update({"statement_name": check_header})
-
-            checkoutput["result"] = list(
+            result_list = list(
                 self.output_statement_result(check_header, check_header, result)
             )
-            checkoutput.update(state_statement_cfg)
-            sys.stdout.write(json.dumps(checkoutput) + "\n")
+
+            if "item_columns" in state_statement_cfg and "value_column" in state_statement_cfg:
+                # Multiline mode: the statement is allowed to return more than
+                # one row. Each row becomes its own checkmk service/item.
+                self._output_custom_sql_multiline(
+                    check_header, result_list, state_statement_cfg
+                )
+            else:
+                # Legacy/default mode: only the first row of the result is used
+                # and the item name comes statically from state_statement_cfg["item"].
+                checkoutput.update({"backend": self.backend})
+                checkoutput.update(
+                    {"backend_service_prefix": self.backend_service_prefix}
+                )
+                checkoutput.update({"db_cstr": self.db_cstr})
+                checkoutput.update({"statement_name": check_header})
+
+                checkoutput["result"] = result_list
+                checkoutput.update(state_statement_cfg)
+                sys.stdout.write(json.dumps(checkoutput) + "\n")
         else:
             for line in self.output_statement_result(
                 check_header, check_header, result
@@ -399,6 +419,215 @@ class BaseDBStrategy(agent_db.AgentDBLog):
                 checkoutput["result"] += line
 
             sys.stdout.write(checkoutput["result"])
+
+    def _extract_custom_sql_data_rows(self, result_list):
+        """
+        Normalize the nested result structure of a custom_sql statement into a
+        plain list of data rows (tuples), regardless of the DB backend.
+
+        Background: for "custom_sql", output_statement_result() (via
+        transform_result()/print_sql()) behaves differently per backend:
+          - postgres: transform_result() yields the *entire* nested result
+            exactly once (`yield result`), so result_list has ONE outer
+            element, which itself is [ [(<col1>, <col2>, ...)], [(row1_col1,
+            ...), ...] ] -- i.e. the column header tuple, then the data rows:
+            result_list = [ [ [(<col1>, ...)], [(row1_col1, ...), ...] ] ]
+          - all other backends: transform_result() yields each subresult of
+            `result` separately, and for a single (non ";"-separated)
+            statement there is exactly one subresult -- the data rows -- so:
+            result_list = [ [(row1_col1, row1_col2, ...), ...] ]
+
+        Args:
+            result_list (list): The value produced by
+                list(self.output_statement_result(...)) for a custom_sql
+                statement.
+
+        Returns:
+            list: A flat list of row tuples, e.g. [(row1_col1, ...), (row2_col1, ...)]
+        """
+        if self.backend == "postgres":
+            if not result_list or len(result_list[0]) < 2:
+                return []
+            return result_list[0][1]
+
+        if len(result_list) < 1:
+            return []
+        return result_list[0]
+
+    def _get_custom_sql_column_names(self, result_list):
+        """
+        Determine the column names belonging to the data rows of a custom_sql
+        statement, so that item_columns/value_column can be given as column
+        names instead of numeric indices.
+
+        Args:
+            result_list (list): The value produced by
+                list(self.output_statement_result(...)) for this statement.
+
+        Returns:
+            tuple[str, ...] | None: Column names in result order, or None if
+            they could not be determined (e.g. the query returned no columns,
+            or the DB driver did not report a cursor description).
+        """
+        if self.backend == "postgres":
+            # See _extract_custom_sql_data_rows() above for the nesting:
+            # result_list[0][0] is the single-element list containing the
+            # column header tuple, so result_list[0][0][0] is that tuple.
+            if not result_list or not result_list[0] or not result_list[0][0]:
+                return None
+            return result_list[0][0][0]
+
+        # All other backends: names were collected by query() into
+        # self.last_column_names (one entry per executed SQL part), since
+        # their query() implementations don't include a header row in the
+        # actual result data.
+        column_names = self.last_column_names
+        if not column_names:
+            return None
+        return column_names[0]
+
+    def _resolve_custom_sql_column(self, column_ref, column_names, check_header):
+        """
+        Resolve one item_columns/value_column entry from agent_db.yaml to a
+        numeric column index.
+
+        Args:
+            column_ref (int | str): Either a 0-based column index, or a
+                column name as it appears in the SQL result.
+            column_names (tuple[str, ...] | None): Column names for the
+                current statement, or None if unavailable.
+            check_header (str): Statement name, used for error messages only.
+
+        Returns:
+            int: The resolved 0-based column index.
+
+        Raises:
+            ValueError: If a column name was given but could not be resolved.
+        """
+        if isinstance(column_ref, bool):
+            # bool is a subclass of int in Python; guard against silently
+            # accepting True/False as column index 1/0.
+            raise ValueError(
+                f"Statement {check_header}: item_columns/value_column entries "
+                f"must be an integer index or a column name string, "
+                f"got: {column_ref!r}"
+            )
+
+        if isinstance(column_ref, int):
+            return column_ref
+
+        if isinstance(column_ref, str):
+            if column_names is None:
+                raise ValueError(
+                    f"Statement {check_header}: column name '{column_ref}' was "
+                    f"used in item_columns/value_column, but no column names "
+                    f"could be determined for this statement/backend. Use a "
+                    f"numeric column index instead, or check the SQL statement."
+                )
+            try:
+                return column_names.index(column_ref)
+            except ValueError:
+                raise ValueError(
+                    f"Statement {check_header}: column '{column_ref}' not "
+                    f"found in result columns {list(column_names)}."
+                )
+
+        raise ValueError(
+            f"Statement {check_header}: item_columns/value_column entries "
+            f"must be an integer index or a column name string, "
+            f"got: {column_ref!r}"
+        )
+
+    def _output_custom_sql_multiline(self, check_header, result_list, state_statement_cfg):
+        """
+        Output one JSON line per data row for a custom_sql statement configured
+        for multiline mode (item_columns + value_column in agent_db.yaml).
+
+        For every row returned by the SQL statement, the item name is built by
+        joining the configured item_columns (and, optionally, item_prefix), and
+        the value is taken from value_column. Every row is written out as its
+        own <<<custom_sql>>> JSON entry, so checkmk discovers one service per row.
+
+        item_columns and value_column may each be given either as a 0-based
+        column index (int) or as a column name (str), e.g.:
+            item_columns: [1]        or   item_columns: ["name"]
+            value_column: 4          or   value_column: "population"
+        Mixing both styles within item_columns is fine, e.g. [0, "district"].
+
+        Args:
+            check_header (str): The header for the output (always "custom_sql" here).
+            result_list (list): The value produced by
+                list(self.output_statement_result(...)) for this statement.
+            state_statement_cfg (dict): Configuration of the current statement
+                from agent_db.yaml (must contain "item_columns" and "value_column").
+
+        Returns:
+            None
+        """
+        item_columns_cfg = state_statement_cfg["item_columns"]
+        value_column_cfg = state_statement_cfg["value_column"]
+        item_prefix = state_statement_cfg.get("item_prefix")
+        item_column_separator = state_statement_cfg.get("item_column_separator", " ")
+
+        data_rows = self._extract_custom_sql_data_rows(result_list)
+
+        if not data_rows:
+            self.log.debug(
+                f"Statement {check_header}: no data rows returned, nothing to output "
+                f"for multiline custom_sql."
+            )
+            return
+
+        column_names = self._get_custom_sql_column_names(result_list)
+
+        try:
+            item_columns = [
+                self._resolve_custom_sql_column(col, column_names, check_header)
+                for col in item_columns_cfg
+            ]
+            value_column = self._resolve_custom_sql_column(
+                value_column_cfg, column_names, check_header
+            )
+        except ValueError as e:
+            self.log.error(str(e))
+            return
+
+        for row in data_rows:
+            try:
+                item_parts = [str(row[idx]).strip() for idx in item_columns]
+            except IndexError:
+                self.log.error(
+                    f"Statement {check_header}: item_columns {item_columns} out of "
+                    f"range for row with {len(row)} columns: {row}"
+                )
+                continue
+
+            item_name = item_column_separator.join(item_parts)
+            if item_prefix:
+                item_name = f"{item_prefix}{item_column_separator}{item_name}"
+
+            try:
+                value = row[value_column]
+            except IndexError:
+                self.log.error(
+                    f"Statement {check_header}: value_column {value_column} out of "
+                    f"range for row with {len(row)} columns: {row}"
+                )
+                continue
+
+            row_checkoutput = {
+                "backend": self.backend,
+                "backend_service_prefix": self.backend_service_prefix,
+                "db_cstr": self.db_cstr,
+                "statement_name": check_header,
+            }
+            row_checkoutput.update(state_statement_cfg)
+            # item/value are computed per row and must win over any (unused)
+            # static "item"/"value" key that might still be present in the yaml.
+            row_checkoutput["item"] = item_name
+            row_checkoutput["value"] = value
+
+            sys.stdout.write(json.dumps(row_checkoutput) + "\n")
 
     @property
     def separator_char(self):
@@ -421,7 +650,21 @@ class BaseDBStrategy(agent_db.AgentDBLog):
         return separator
 
     @staticmethod
-    def query(cursor, sqlstatement):
+    def _column_names_from_cursor(cursor):
+        """
+        Read the column names of the last executed statement from the cursor's
+        DB-API "description" attribute (standard across psycopg2, pyodbc,
+        mysql-connector, cx_Oracle/oracledb, ...).
+
+        Returns:
+            tuple[str, ...] | None: Column names, or None if not available
+            (e.g. the statement did not return a result set).
+        """
+        if cursor.description is None:
+            return None
+        return tuple(desc[0] for desc in cursor.description)
+
+    def query(self, cursor, sqlstatement):
         """
         Run an SQL statement with an open cursor.
 
@@ -432,8 +675,10 @@ class BaseDBStrategy(agent_db.AgentDBLog):
         else:
             sqls = sqlstatement.split(";")
 
+        self.last_column_names = []
         for sql in sqls:
             cursor.execute(sql)
+            self.last_column_names.append(self._column_names_from_cursor(cursor))
             ret = cursor.fetchall()
             yield ret
 
@@ -528,7 +773,16 @@ class BaseDBStrategy(agent_db.AgentDBLog):
                 mtime_cache_file, cached_data = cache_result
                 stats["status"] = "OK"
                 stats["runtime"] = 0.0
-                results = cached_data
+                if isinstance(cached_data, dict) and "results" in cached_data:
+                    # Cache format written by this version (includes column names,
+                    # needed to resolve item_columns/value_column given as names).
+                    results = cached_data["results"]
+                    self.last_column_names = cached_data.get("column_names")
+                else:
+                    # Backward compatible with cache files written by older
+                    # agent_db versions (plain results list, no column names).
+                    results = cached_data
+                    self.last_column_names = None
                 self.print_db_stats(self.db_cstr, statement, stats)
                 return (results, mtime_cache_file)
 
@@ -548,7 +802,14 @@ class BaseDBStrategy(agent_db.AgentDBLog):
                 if cache_time_sec is not None and cache_key is not None:
                     # Write the result to cache
                     self.log.debug(f"Writing cache for: {cache_key}")
-                    cache.write_cache(self.cache_dir, cache_key, results)
+                    cache.write_cache(
+                        self.cache_dir,
+                        cache_key,
+                        {
+                            "results": results,
+                            "column_names": self.last_column_names,
+                        },
+                    )
             except Exception as e:
                 self.log.error(f"Error running query {statement}: {str(e)}")
                 stats["status"] = "CRIT"

--- a/lib/python3/cmk/special_agents/db/cmk_mssql.py
+++ b/lib/python3/cmk/special_agents/db/cmk_mssql.py
@@ -226,16 +226,19 @@ class DBStrategy(basedb.BaseDBStrategy):
                 )
             return sql_output_string
 
-    @staticmethod
-    def query(cursor, sqlstatement):
+    def query(self, cursor, sqlstatement):
         if sqlstatement.startswith("BEGIN") or sqlstatement.startswith("DECLARE"):
             sqls = [sqlstatement]
         else:
             sqls = sqlstatement.split(";")
 
+        self.last_column_names = []
         for sql in sqls:
             cursor.execute(sql)
             while True:
+                self.last_column_names.append(
+                    self._column_names_from_cursor(cursor)
+                )
                 ret = cursor.fetchall()
                 yield ret
                 if not cursor.nextset():

--- a/lib/python3/cmk_addons/plugins/agent_db/agent_based/custom_sql.py
+++ b/lib/python3/cmk_addons/plugins/agent_db/agent_based/custom_sql.py
@@ -49,6 +49,12 @@ def _return_no_data_in_agent_output():
 
 
 def _get_value_from_checkdata(checkdata):
+    # Multiline mode (item_columns + value_column configured in agent_db.yaml):
+    # the special agent already computed the value for this row/item.
+    if "value" in checkdata:
+        return checkdata["value"]
+
+    # Legacy/default mode: only the first row of the raw result is evaluated.
     if checkdata["backend"] == "postgres":
         value = checkdata["result"][0][1][0][0]
     else:

--- a/lib/python3/cmk_addons/plugins/agent_db/etc/agent_db_default.yml
+++ b/lib/python3/cmk_addons/plugins/agent_db/etc/agent_db_default.yml
@@ -288,15 +288,32 @@ cmk_postgres:
       packages:
         - basic
 
+    # Multiline custom_sql example:
+    # "select * from city limit 10" returns several rows with the columns
+    # (id, name, countrycode, district, population) at index 0..4.
+    #
+    # If "item_columns" and "value_column" are both set, agent_db switches
+    # into multiline mode: instead of using only the first row of the result
+    # (as with a static "item"), it creates ONE checkmk service per row.
+    #
+    # - item_columns:  list of 0-based column indices that are combined to
+    #                   build the item/service name (multiple columns allowed)
+    # - item_prefix:            optional text prepended to the item name
+    # - item_column_separator:  optional separator used to join item_columns
+    #                            and item_prefix (default: " ")
+    # - value_column:  0-based column index that contains the actual value
+    #                   to be checked (number or string)
+    #
+    # NOTE: item_columns/value_column and a static "item" are mutually
+    # exclusive. If "item_columns" and "value_column" are present, they take
+    # precedence and "item" is ignored.
     postgres_select_cities:
       separator: sep(0)
       check_header: custom_sql
-      #has_header_row: true
-      # if a item is defined, item_prefix, item_column, value_column are ignored
-      item: City population
-      #item_prefix: City
-      #item_column: name
-      #value_column: population
+      item_columns: [1]
+      item_prefix: City
+      item_column_separator: " "
+      value_column: 4
       timeout_sec: 2
       type: number
       metric: population


### PR DESCRIPTION
`custom_sql`-Statements konnten bisher nur eine einzelne Ergebniszeile verarbeiten: Der Item-Name kam statisch aus `item` in der `agent_db.yaml`, und ausgewertet wurde immer nur die erste Zeile des Ergebnisses. Statements, die pro Ausführung mehrere Zeilen liefern (z. B. "ein Wert pro Kategorie/Typ/Host") ließen sich damit nicht sinnvoll abbilden – man hätte für jede Kategorie ein eigenes Statement mit fest codiertem Filter anlegen müssen.
 
Dieser PR führt einen optionalen **Multiline-Modus** ein: Über neue Konfigurationsfelder in der `agent_db.yaml` lässt sich festlegen, aus welchen Spalten sich der Item-/Service-Name zusammensetzt und welche Spalte den auszuwertenden Wert enthält. Der Special Agent erzeugt daraus **einen checkmk-Service pro Ergebniszeile**.
 
## Neue Konfigurationsoptionen (agent_db.yaml)
 
```yaml
postgres_select_cities:
  separator: sep(0)
  check_header: custom_sql
  item_columns: [0, 1]          # Spalten für den Item-Namen (Index ODER Spaltenname)
  item_prefix: "Cities"          # optional, wird vorangestellt
  item_column_separator: " "    # optional, Default: " "
  value_column: 3               # Spalte mit dem auszuwertenden Wert (Index ODER Spaltenname)
  timeout_sec: 2
  type: number
  metric: population
  packages: [custom_multiline]
```
 
- **`item_columns`** (Liste, Pflicht für Multiline): eine oder mehrere Spalten, die zu einem Item-Namen zusammengefügt werden. Jeder Eintrag kann ein 0-basierter Index (`0`) oder ein Spaltenname (`"event_type"`) sein, auch gemischt.
- **`value_column`** (Pflicht für Multiline): Spalte mit dem eigentlichen Prüfwert, ebenfalls als Index oder Name angebbar.
- **`item_column_separator`** (optional, Default `" "`): Trennzeichen zwischen den `item_columns`-Werten (und dem Prefix).

**Rückwärtskompatibilität:** Ist `item_columns`/`value_column` **nicht** gesetzt, verhält sich das Statement exakt wie bisher (statisches `item`, nur erste Zeile wird ausgewertet). Bestehende `agent_db.yaml`-Konfigurationen sind ohne Anpassung weiter lauffähig.

--- 
# TL;TR

## Geänderte Dateien
 
### `lib/python3/cmk/special_agents/db/basedb.py`
- `_output_result()`: neue Weiche – bei gesetztem `item_columns`/`value_column` wird `_output_custom_sql_multiline()` aufgerufen, sonst der bisherige Pfad.
- `_extract_custom_sql_data_rows()`: normalisiert die je nach Backend unterschiedlich verschachtelte Rohergebnis-Struktur zu einer flachen Liste von Ergebniszeilen.
- `_get_custom_sql_column_names()`: ermittelt die Spaltennamen der aktuellen Abfrage (bei Postgres aus der ohnehin vorhandenen Header-Zeile, bei den übrigen Backends aus `self.last_column_names`).
- `_resolve_custom_sql_column()`: löst einen `item_columns`/`value_column`-Eintrag (Index **oder** Name) zu einem numerischen Index auf.
- `_output_custom_sql_multiline()`: baut pro Ergebniszeile Item-Name und Wert und schreibt sie als eigene JSON-Zeile in den Agent-Output.
- `query()` (Basis-Implementierung, wird von MySQL und Oracle geerbt): erfasst zusätzlich die Spaltennamen aus `cursor.description` je ausgeführtem SQL-Teil.
- `exec_sql()`: Spaltennamen werden zusammen mit dem Ergebnis gecacht (rückwärtskompatibel zu alten Cache-Dateien), damit die Namensauflösung auch bei einem Cache-Treffer funktioniert.
- `__init__()`: neues Attribut `self.last_column_names`.
### `lib/python3/cmk/special_agents/db/cmk_mssql.py`
- MSSQL hat eine eigene `query()`-Implementierung (wegen `nextset()` für mehrere Ergebnismengen) und überschreibt damit die Basis-Implementierung vollständig. Deshalb musste die gleiche Spaltennamen-Erfassung hier separat ergänzt werden, passend zum `nextset()`-Loop.
- MySQL und Oracle benötigten keine Anpassung, da sie keine eigene `query()`-Methode haben und automatisch die angepasste Basis-Implementierung aus `basedb.py` erben. Postgres benötigte ebenfalls keine Anpassung, da seine `query()`-Methode die Spaltennamen bereits als Header-Zeile mit ausliefert.
### `lib/python3/cmk_addons/plugins/agent_db/agent_based/custom_sql.py`
- `_get_value_from_checkdata()`: liest bevorzugt den vom Special Agent im Multiline-Modus mitgelieferten `value`-Key. Ist dieser nicht vorhanden, greift unverändert die bisherige, backend-abhängige Extraktion aus der rohen `result`-Struktur (Legacy-Pfad).
### `lib/python3/cmk_addons/plugins/agent_db/etc/agent_db_default.yml`
- Beispiel-Statement `postgres_select_cities` auf die neue Multiline-Syntax umgebaut, inklusive Kommentarblock, der alle neuen Felder erklärt.
